### PR TITLE
Support older versions of containers

### DIFF
--- a/histogram-simple.cabal
+++ b/histogram-simple.cabal
@@ -22,7 +22,7 @@ library
     Haskell2010
   build-depends:
       base >= 4.7 && < 5
-    , containers >= 0.6.2.1 && < 0.7
+    , containers >= 0.5.11 && < 0.7
   ghc-options:
     -Wall
     -Werror

--- a/src/Data/Histogram/Lazy.hs
+++ b/src/Data/Histogram/Lazy.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module Data.Histogram.Lazy
   ( Histogram
   , toMap
@@ -108,4 +109,8 @@ lookup k (Histogram m) = fromMaybe 0 (m M.!? k)
 
 -- | Returns true when there is no key that is nonzero in both arguments.
 disjoint :: Ord k => Histogram k -> Histogram k -> Bool
+#if MIN_VERSION_containers (0,6,2)
 disjoint (Histogram m1) (Histogram m2) = M.disjoint m1 m2
+#else
+disjoint (Histogram m1) (Histogram m2) = M.null (M.intersection m1 m2)
+#endif


### PR DESCRIPTION
This PR enables compiling histogram-simple with versions of `containers` that don't include the `disjoint` function introduced in `containers-0.6.2.1`.